### PR TITLE
Adding ,for now ignored, php init config files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,6 @@
 # IDEs
 .idea
+
+# PHP configs
+*.ini
+*.ini-*


### PR DESCRIPTION
	- As Im using docker for the apache server I used the command:
		 $ docker cp php-beginner:/usr/local/etc/php ./config
	to copiyall the files from the container where .ini were
	- Then I create a new file there, php.ini
	- Once created I had to restart the container to load the changes, so
	every change I made over the php.ini I will need to restart de container
	(instead of a complete server)
	- Now I have a dir in a_beginner with all the config files to learn some while

Now I am able to change some default config from the server using the **php.ini**